### PR TITLE
Release v0.3.0

### DIFF
--- a/src/main/java/io/ooni/mk/MKCollectorResubmitResults.java
+++ b/src/main/java/io/ooni/mk/MKCollectorResubmitResults.java
@@ -1,0 +1,45 @@
+// Part of Measurement Kit <https://measurement-kit.github.io/>.
+// Measurement Kit is free software under the BSD license. See AUTHORS
+// and LICENSE for more information on the copying conditions.
+package io.ooni.mk;
+
+/** MKCollectorResubmitResults contains the results of resubmitting a
+ * specific measurement to the OONI collector. */
+public class MKCollectorResubmitResults {
+    long handle = 0;
+
+    final static native boolean Good(long handle);
+
+    final static native String Content(long handle);
+
+    final static native String Logs(long handle);
+
+    final static native void Delete(long handle);
+
+    MKCollectorResubmitResults(long n) {
+        handle = n;
+    }
+
+    /** isGood returns whether we succeded. */
+    public boolean isGood() {
+        return Good(handle);
+    }
+
+    /** getUpdatedSerializedMeasurement returns the serialized measurement
+     * where all the fields that should have been updated, e.g., the
+     * report ID, have already been updated  with the new values provided
+     * by the OONI collector as part of resubmitting. */
+    public String getUpdatedSerializedMeasurement() {
+        return Content(handle);
+    }
+
+    /** getLogs returns the logs as one-or-more newline-separated
+     * lines containing only UTF-8 characters. */
+    public String getLogs() {
+        return Logs(handle);
+    }
+
+    @Override public synchronized void finalize() {
+        Delete(handle);
+    }
+}

--- a/src/main/java/io/ooni/mk/MKCollectorResubmitResults.java
+++ b/src/main/java/io/ooni/mk/MKCollectorResubmitResults.java
@@ -27,7 +27,7 @@ public class MKCollectorResubmitResults {
 
     /** getUpdatedSerializedMeasurement returns the serialized measurement
      * where all the fields that should have been updated, e.g., the
-     * report ID, have already been updated  with the new values provided
+     * report ID, have already been updated with the new values provided
      * by the OONI collector as part of resubmitting. */
     public String getUpdatedSerializedMeasurement() {
         return Content(handle);

--- a/src/main/java/io/ooni/mk/MKCollectorResubmitSettings.java
+++ b/src/main/java/io/ooni/mk/MKCollectorResubmitSettings.java
@@ -1,0 +1,63 @@
+// Part of Measurement Kit <https://measurement-kit.github.io/>.
+// Measurement Kit is free software under the BSD license. See AUTHORS
+// and LICENSE for more information on the copying conditions.
+package io.ooni.mk;
+
+/** MKCollectorResubmitSettings contains the settings configuring
+ * the resubmission of a report with the OONI collector. */
+public class MKCollectorResubmitSettings {
+    long handle = 0;
+
+    final static native long New();
+
+    final static native void SetTimeout(long handle, long timeout);
+
+    final static native void SetCABundlePath(long handle, String path);
+
+    final static native void SetContent(long handle, String content);
+
+    final static native long Perform(long handle);
+
+    final static native void Delete(long handle);
+
+    /** MKCollectorResubmitSettings constructs new, default settings. */
+    public MKCollectorResubmitSettings() {
+        handle = New();
+        if (handle == 0) {
+            throw new RuntimeException(
+                    "MKCollectorResubmitSettings.New failed");
+        }
+    }
+
+    /** setTimeout sets the number of seconds after which pending
+     * requests are aborted by Measurement Kit. */
+    public void setTimeout(long timeout) {
+        SetTimeout(handle, timeout);
+    }
+
+    /** setCABundlePath sets the path of the CA bundle to use. */
+    public void setCABundlePath(String path) {
+        SetCABundlePath(handle, path);
+    }
+
+    /** setSerializedMeasurement sets the serialized measurement that
+     * you want to resubmit to the OONI collector. */
+    public void setSerializedMeasurement(String measurement) {
+        SetContent(handle, measurement);
+    }
+
+    @Override public synchronized void finalize() {
+        Delete(handle);
+    }
+
+    /** perform resubmits the configured serialized measurements with current
+     * settings to the OONI collector and returns the results. */
+    public MKCollectorResubmitResults perform() {
+        long results = Perform(handle);
+        if (results == 0) {
+            throw new RuntimeException(
+                    "MKCollectorResubmitSettings.Perform failed");
+        }
+        return new MKCollectorResubmitResults(results);
+    }
+}

--- a/src/main/java/io/ooni/mk/MKEvent.java
+++ b/src/main/java/io/ooni/mk/MKEvent.java
@@ -3,7 +3,7 @@
 // information on the copying conditions.
 package io.ooni.mk;
 
-public class MKEvent {
+class MKEvent {
     long handle = 0;
 
     final static native String Serialize(long handle);

--- a/src/main/java/io/ooni/mk/MKGeoIPLookupResults.java
+++ b/src/main/java/io/ooni/mk/MKGeoIPLookupResults.java
@@ -3,60 +3,56 @@
 // and LICENSE for more information on the copying conditions.
 package io.ooni.mk;
 
+/** MKGeoIPLookupResults contains the results of a GeoIP lookup. */
 public class MKGeoIPLookupResults {
     long handle = 0;
 
     final static native boolean Good(long handle);
 
-    final static native double GetBytesSent(long handle);
-
-    final static native double GetBytesRecv(long handle);
-
     final static native String GetProbeIP(long handle);
 
-    final static native long GetProbeASN(long handle);
+    final static native String GetProbeASN(long handle);
 
     final static native String GetProbeCC(long handle);
 
     final static native String GetProbeOrg(long handle);
 
-    final static native byte[] GetLogs(long handle);
+    final static native String GetLogs(long handle);
 
     final static native void Delete(long handle);
 
-    protected MKGeoIPLookupResults(long n) {
+    MKGeoIPLookupResults(long n) {
         handle = n;
     }
 
-    public boolean good() {
+    /** isGood returns whether we succeded. */
+    public boolean isGood() {
         return Good(handle);
     }
 
-    public double getBytesSent() {
-        return GetBytesSent(handle);
-    }
-
-    public double getBytesRecv() {
-        return GetBytesRecv(handle);
-    }
-
+    /** getProbeIP returns the probe IP. */
     public String getProbeIP() {
         return GetProbeIP(handle);
     }
 
-    public long getProbeASN() {
+    /** getProbeASN returns the probe ASN. */
+    public String getProbeASN() {
         return GetProbeASN(handle);
     }
 
+    /** getProbeCC returns the probe CC. */
     public String getProbeCC() {
         return GetProbeCC(handle);
     }
 
+    /** getProbeOrg returns the probe ASN organization. */
     public String getProbeOrg() {
         return GetProbeOrg(handle);
     }
 
-    public byte[] getLogs() {
+    /** getLogs returns the logs as one or more newline separated
+     * lines containing only UTF-8 characters. */
+    public String getLogs() {
         return GetLogs(handle);
     }
 

--- a/src/main/java/io/ooni/mk/MKGeoIPLookupSettings.java
+++ b/src/main/java/io/ooni/mk/MKGeoIPLookupSettings.java
@@ -3,6 +3,7 @@
 // and LICENSE for more information on the copying conditions.
 package io.ooni.mk;
 
+/** MKGeoIPLookupSettings contains the GeoIP lookup settings. */
 public class MKGeoIPLookupSettings {
     long handle = 0;
 
@@ -20,24 +21,33 @@ public class MKGeoIPLookupSettings {
 
     final static native void Delete(long handle);
 
+    /** MKGeoIPLookupSettings constructs new, default settings. */
     public MKGeoIPLookupSettings() {
-        if ((handle = New()) == 0) {
+        handle = New();
+        if (handle == 0) {
             throw new RuntimeException("MKGeoIPLookupSettings.New failed");
         }
     }
 
+    /** setTimeout sets the number of seconds after which pending
+     * requests are aborted by Measurement Kit. */
     public void setTimeout(long timeout) {
         SetTimeout(handle, timeout);
     }
 
+    /** setCABundlePath sets the path of the CA bundle to use. */
     public void setCABundlePath(String path) {
         SetCABundlePath(handle, path);
     }
 
+    /** setCountryDBPath sets the path of the MaxMind country
+     * database to use. */
     public void setCountryDBPath(String path) {
         SetCountryDBPath(handle, path);
     }
 
+    /** setASNDBPath sets the path of the MaxMind ASN
+     * database to use. */
     public void setASNDBPath(String path) {
         SetASNDBPath(handle, path);
     }
@@ -46,6 +56,7 @@ public class MKGeoIPLookupSettings {
         Delete(handle);
     }
 
+    /** perform performs a GeoIP lookup with current settings. */
     public MKGeoIPLookupResults perform() {
         long results = Perform(handle);
         if (results == 0) {

--- a/src/main/java/io/ooni/mk/MKOrchestraResults.java
+++ b/src/main/java/io/ooni/mk/MKOrchestraResults.java
@@ -3,28 +3,31 @@
 // and LICENSE for more information on the copying conditions.
 package io.ooni.mk;
 
-public class MKOrchestraResult {
+/** MKOrchestraResults contains the results of an orchestra operation. */
+public class MKOrchestraResults {
     long handle = 0;
 
     final static native boolean Good(long handle);
 
-    final static native byte[] GetBinaryLogs(long handle);
+    final static native String GetLogs(long handle);
 
     final static native void Delete(long handle);
 
-    protected MKOrchestraResult(long n) {
+    MKOrchestraResults(long n) {
         handle = n;
     }
 
-    public boolean good() {
+    /** isGood indicates whether we succeeded. */
+    public boolean isGood() {
         return Good(handle);
     }
 
-    public byte[] getBinaryLogs() {
-        return GetBinaryLogs(handle);
+    /** getLogs returns the logs as one or more UTF-8 lines of text. */
+    public String getLogs() {
+        return GetLogs(handle);
     }
 
     @Override public synchronized void finalize() {
-    Delete(handle);
+        Delete(handle);
     }
 }

--- a/src/main/java/io/ooni/mk/MKOrchestraSettings.java
+++ b/src/main/java/io/ooni/mk/MKOrchestraSettings.java
@@ -3,7 +3,8 @@
 // and LICENSE for more information on the copying conditions.
 package io.ooni.mk;
 
-public class MKOrchestraClient {
+/** MKOrchestraSettings contains the orchestra settings. */
+public class MKOrchestraSettings {
     long handle = 0;
 
     final static native long New();
@@ -48,90 +49,117 @@ public class MKOrchestraClient {
 
     final static native void Delete(long handle);
 
-    public MKOrchestraClient() {
+    /** MKOrchestraSettings creates new, default settings. */
+    public MKOrchestraSettings() {
         if ((handle = New()) == 0) {
             throw new RuntimeException("MKOrchestraClient.New failed");
         }
     }
 
+    /** setAvailableBandwidth sets the bandwidth that a probe is
+     * available to commit to running measurements. */
     public void setAvailableBandwidth(String value) {
         SetAvailableBandwidth(handle, value);
     }
 
+    /** setDeviceToken sets the token to be later used to send
+     * push notifications to the device. */
     public void setDeviceToken(String value) {
         SetDeviceToken(handle, value);
     }
 
+    /** setCABundlePath sets the path of the CA bundle to use. */
     public void setCABundlePath(String value) {
         SetCABundlePath(handle, value);
     }
 
+    /** setGeoIPCountryPath sets the path of the MaxMind country database. */
     public void setGeoIPCountryPath(String value) {
         SetGeoIPCountryPath(handle, value);
     }
 
+    /** setGeoIPASNPath sets the path of the MaxMind ASN database. */
     public void setGeoIPASNPath(String value) {
         SetGeoIPASNPath(handle, value);
     }
 
+    /** setLanguage sets the device's language. */
     public void setLanguage(String value) {
         SetLanguage(handle, value);
     }
 
+    /** setNetworkType sets the current network type. */
     public void setNetworkType(String value) {
         SetNetworkType(handle, value);
     }
 
+    /** setPlatform sets the device's platform */
     public void setPlatform(String value) {
         SetPlatform(handle, value);
     }
 
+    /** setProbeASN sets the ASN in which we are. */
     public void setProbeASN(String value) {
         SetProbeASN(handle, value);
     }
 
+    /** setProbeCC sets the country code in which we are. */
     public void setProbeCC(String value) {
         SetProbeCC(handle, value);
     }
 
+    /** setProbeFamily sets an identifier for a group of probes. */
     public void setProbeFamily(String value) {
         SetProbeFamily(handle, value);
     }
 
+    /** setProbeTimezone sets the timezone of the probe. */
     public void setProbeTimezone(String value) {
         SetProbeTimezone(handle, value);
     }
 
+    /** setRegistryURL sets the base URL to contact the registry. */
     public void setRegistryURL(String value) {
         SetRegistryURL(handle, value);
     }
 
+    /** setSecretsFile sets the path of the file where to store
+     * orchestra related secrets. */
     public void setSecretsFile(String value) {
         SetSecretsFile(handle, value);
     }
 
+    /** setSoftwareName sets the name of the app. */
     public void setSoftwareName(String value) {
         SetSoftwareName(handle, value);
     }
 
+    /** setSoftwareVersion sets the version of the app. */
     public void setSoftwareVersion(String value) {
         SetSoftwareVersion(handle, value);
     }
 
+    /** addSupportedTest adds a test to the set of supported tests. */
     public void addSupportedTest(String value) {
         AddSupportedTest(handle, value);
     }
 
+    /** setTimeout sets the number of seconds after which
+     * outstanding requests are aborted. */
     public void setTimeout(long value) {
         SetTimeout(handle, value);
     }
 
-    public MKOrchestraResult sync() {
+    /** updateOrRegister will either update the status of the probe with
+     * the registry, or register the probe with the registry, depending
+     * on whether we did already register or not. */
+    public MKOrchestraResults updateOrRegister() {
         long result = Sync(handle);
         if (result == 0) {
-            throw new RuntimeException("MKOrchestraClient.Sync failed");
+            throw new RuntimeException(
+                    "MKOrchestraClient.updateOrRegister failed");
         }
-        return new MKOrchestraResult(result);
+        return new MKOrchestraResults(result);
     }
 
     @Override public synchronized void finalize() {

--- a/src/main/java/io/ooni/mk/MKTask.java
+++ b/src/main/java/io/ooni/mk/MKTask.java
@@ -3,10 +3,11 @@
 // information on the copying conditions.
 package io.ooni.mk;
 
+/** MKTask is a task that Measurement Kit is running. */
 public class MKTask {
     long handle = 0;
 
-    final static native long StartNettest(String settings);
+    final static native long Start(String settings);
 
     final static native boolean IsDone(long handle);
 
@@ -20,26 +21,32 @@ public class MKTask {
         handle = n;
     }
 
-    public static MKTask startNettest(String settings) {
-        long handle = StartNettest(settings);
+    /** start starts a new task with the specified settings that must
+     * be a valid serialized JSON string. */
+    public static MKTask start(String settings) {
+        long handle = Start(settings);
         if (handle == 0) {
-            throw new RuntimeException("MKTask.startNettest failed");
+            throw new RuntimeException("MKTask.start failed");
         }
         return new MKTask(handle);
     }
 
+    /** isDone returns true when the task is done. */
     public boolean isDone() {
         return IsDone(handle);
     }
 
-    public MKEvent waitForNextEvent() {
+    /** waitForNextEvent blocks until the task generates the next event
+     * and then returns such events as a serialized JSON. */
+    public String waitForNextEvent() {
         long event = WaitForNextEvent(handle);
         if (event == 0) {
             throw new RuntimeException("MKTask.WaitForNextEvent failed");
         }
-        return new MKEvent(event);
+        return new MKEvent(event).serialize();
     }
 
+    /** interrupt interrupts the task. */
     public void interrupt() {
         Interrupt(handle);
     }

--- a/src/main/java/io/ooni/mk/MKVersion.java
+++ b/src/main/java/io/ooni/mk/MKVersion.java
@@ -3,6 +3,8 @@
 // information on the copying conditions.
 package io.ooni.mk;
 
+/** MKVersion allows to get version information. */
 public class MKVersion {
-    public final static native String getVersion();
+    /** getVersionMK returns Measurement Kit version as a string. */
+    public final static native String getVersionMK();
 }

--- a/src/mkall/cpp/collector.cpp
+++ b/src/mkall/cpp/collector.cpp
@@ -1,0 +1,49 @@
+// Part of measurement-kit <https://measurement-kit.github.io/>.
+// Measurement-kit is free software. See AUTHORS and LICENSE for more
+// information on the copying conditions.
+
+#include "mkall.h"
+
+// We should use collector.h from MK v0.10.1 onwards
+#include <measurement_kit/internal/collector/collector.h>
+
+#include "mkall_util.h"
+
+MKALL_GET_BOOLEAN(MKCollectorResubmitResults_Good,
+                  mk_collector_resubmit_response_good,
+                  mk_collector_resubmit_response_t)
+
+MKALL_GET_STRING(MKCollectorResubmitResults_Content,
+                 mk_collector_resubmit_response_content,
+                 mk_collector_resubmit_response_t)
+
+MKALL_GET_LOGS(MKCollectorResubmitResults_Logs,
+               mk_collector_resubmit_response_logs_size,
+               mk_collector_resubmit_response_logs_at,
+               mk_collector_resubmit_response_t)
+
+MKALL_DELETE(MKCollectorResubmitResults_Delete,
+             mk_collector_resubmit_response_delete,
+             mk_collector_resubmit_response_t)
+
+MKALL_NEW(MKCollectorResubmitSettings_New, mk_collector_resubmit_request_new)
+
+MKALL_SET_LONG(MKCollectorResubmitSettings_SetTimeout,
+               mk_collector_resubmit_request_set_timeout,
+               mk_collector_resubmit_request_t)
+
+MKALL_SET_STRING(MKCollectorResubmitSettings_SetCABundlePath,
+                 mk_collector_resubmit_request_set_ca_bundle_path,
+                 mk_collector_resubmit_request_t)
+
+MKALL_SET_STRING(MKCollectorResubmitSettings_SetContent,
+                 mk_collector_resubmit_request_set_content,
+                 mk_collector_resubmit_request_t)
+
+MKALL_GET_POINTER(MKCollectorResubmitSettings_Perform,
+                  mk_collector_resubmit,
+                  mk_collector_resubmit_request_t)
+
+MKALL_DELETE(MKCollectorResubmitSettings_Delete,
+             mk_collector_resubmit_request_delete,
+             mk_collector_resubmit_request_t)

--- a/src/mkall/cpp/collector.cpp
+++ b/src/mkall/cpp/collector.cpp
@@ -4,7 +4,6 @@
 
 #include "mkall.h"
 
-// We should use collector.h from MK v0.10.1 onwards
 #include <measurement_kit/internal/collector/collector.h>
 
 #include "mkall_util.h"

--- a/src/mkall/cpp/ffi.cpp
+++ b/src/mkall/cpp/ffi.cpp
@@ -10,7 +10,7 @@
 
 #include "mkall_util.h"
 
-MKALL_NEW_WITH_STRING_ARGUMENT(MKTask_StartNettest, mk_nettest_start)
+MKALL_NEW_WITH_STRING_ARGUMENT(MKTask_Start, mk_task_start)
 
 MKALL_GET_BOOLEAN(MKTask_IsDone, mk_task_is_done, mk_task_t)
 

--- a/src/mkall/cpp/geoiplookup.cpp
+++ b/src/mkall/cpp/geoiplookup.cpp
@@ -6,68 +6,61 @@
 
 #include <limits.h>
 
-#include <measurement_kit/vendor/mkgeoip.h>
+#include <measurement_kit/internal/geoiplookup/geoiplookup.h>
 
 #include "mkall_util.h"
 
 MKALL_GET_BOOLEAN(MKGeoIPLookupResults_Good,
-                  mkgeoip_lookup_results_good_v2,
-                  mkgeoip_lookup_results_t)
-
-MKALL_GET_DOUBLE(MKGeoIPLookupResults_GetBytesSent,
-                 mkgeoip_lookup_results_get_bytes_sent_v2,
-                 mkgeoip_lookup_results_t)
-
-MKALL_GET_DOUBLE(MKGeoIPLookupResults_GetBytesRecv,
-                 mkgeoip_lookup_results_get_bytes_recv_v2,
-                 mkgeoip_lookup_results_t)
+                  mk_geoiplookup_response_good,
+                  mk_geoiplookup_response_t)
 
 MKALL_GET_STRING(MKGeoIPLookupResults_GetProbeIP,
-                 mkgeoip_lookup_results_get_probe_ip_v2,
-                 mkgeoip_lookup_results_t)
+                 mk_geoiplookup_response_ip,
+                 mk_geoiplookup_response_t)
 
-MKALL_GET_LONG(MKGeoIPLookupResults_GetProbeASN,
-               mkgeoip_lookup_results_get_probe_asn_v2,
-               mkgeoip_lookup_results_t)
+MKALL_GET_STRING(MKGeoIPLookupResults_GetProbeASN,
+                 mk_geoiplookup_response_asn,
+                 mk_geoiplookup_response_t)
 
 MKALL_GET_STRING(MKGeoIPLookupResults_GetProbeCC,
-                 mkgeoip_lookup_results_get_probe_cc_v2,
-                 mkgeoip_lookup_results_t)
+                 mk_geoiplookup_response_cc,
+                 mk_geoiplookup_response_t)
 
 MKALL_GET_STRING(MKGeoIPLookupResults_GetProbeOrg,
-                 mkgeoip_lookup_results_get_probe_org_v2,
-                 mkgeoip_lookup_results_t)
+                 mk_geoiplookup_response_org,
+                 mk_geoiplookup_response_t)
 
-MKALL_GET_BYTE_ARRAY(MKGeoIPLookupResults_GetLogs,
-                     mkgeoip_lookup_results_get_logs_binary_v2,
-                     mkgeoip_lookup_results_t)
+MKALL_GET_LOGS(MKGeoIPLookupResults_GetLogs,
+               mk_geoiplookup_response_logs_size,
+               mk_geoiplookup_response_logs_at,
+               mk_geoiplookup_response_t)
 
 MKALL_DELETE(MKGeoIPLookupResults_Delete,
-             mkgeoip_lookup_results_delete,
-             mkgeoip_lookup_results_t)
+             mk_geoiplookup_response_delete,
+             mk_geoiplookup_response_t)
 
-MKALL_NEW(MKGeoIPLookupSettings_New, mkgeoip_lookup_settings_new_nonnull)
+MKALL_NEW(MKGeoIPLookupSettings_New, mk_geoiplookup_request_new)
 
 MKALL_SET_LONG(MKGeoIPLookupSettings_SetTimeout,
-               mkgeoip_lookup_settings_set_timeout_v2,
-               mkgeoip_lookup_settings_t)
+               mk_geoiplookup_request_set_timeout,
+               mk_geoiplookup_request_t)
 
 MKALL_SET_STRING(MKGeoIPLookupSettings_SetCountryDBPath,
-                 mkgeoip_lookup_settings_set_country_db_path_v2,
-                 mkgeoip_lookup_settings_t)
+                 mk_geoiplookup_request_set_country_db_path,
+                 mk_geoiplookup_request_t)
 
 MKALL_SET_STRING(MKGeoIPLookupSettings_SetASNDBPath,
-                 mkgeoip_lookup_settings_set_asn_db_path_v2,
-                 mkgeoip_lookup_settings_t)
+                 mk_geoiplookup_request_set_asn_db_path,
+                 mk_geoiplookup_request_t)
 
 MKALL_SET_STRING(MKGeoIPLookupSettings_SetCABundlePath,
-                 mkgeoip_lookup_settings_set_ca_bundle_path_v2,
-                 mkgeoip_lookup_settings_t)
+                 mk_geoiplookup_request_set_ca_bundle_path,
+                 mk_geoiplookup_request_t)
 
 MKALL_GET_POINTER(MKGeoIPLookupSettings_Perform,
-                  mkgeoip_lookup_settings_perform_nonnull,
-                  mkgeoip_lookup_settings_t)
+                  mk_geoiplookup_perform,
+                  mk_geoiplookup_request_t)
 
 MKALL_DELETE(MKGeoIPLookupSettings_Delete,
-             mkgeoip_lookup_settings_delete,
-             mkgeoip_lookup_settings_t)
+             mk_geoiplookup_request_delete,
+             mk_geoiplookup_request_t)

--- a/src/mkall/cpp/orchestra.cpp
+++ b/src/mkall/cpp/orchestra.cpp
@@ -6,101 +6,101 @@
 
 #include <limits.h>
 
-#include <measurement_kit/mkapi/orchestra.h>
+#include <measurement_kit/internal/mkapi/orchestra.h>
 
 #include "mkall_util.h"
 
-MKALL_GET_BOOLEAN(MKOrchestraResult_Good,
+MKALL_GET_BOOLEAN(MKOrchestraResults_Good,
                   mkapi_orchestra_result_good,
                   mkapi_orchestra_result_t)
 
-MKALL_GET_BYTE_ARRAY(MKOrchestraResult_GetBinaryLogs,
-                     mkapi_orchestra_result_get_binary_logs,
-                     mkapi_orchestra_result_t)
+MKALL_GET_LOGS_FROM_BINARY_ARRAY(MKOrchestraResults_GetLogs,
+                                 mkapi_orchestra_result_get_binary_logs,
+                                 mkapi_orchestra_result_t)
 
-MKALL_DELETE(MKOrchestraResult_Delete,
+MKALL_DELETE(MKOrchestraResults_Delete,
              mkapi_orchestra_result_delete,
              mkapi_orchestra_result_t)
 
-MKALL_NEW(MKOrchestraClient_New,
+MKALL_NEW(MKOrchestraSettings_New,
           mkapi_orchestra_client_new)
 
-MKALL_SET_STRING(MKOrchestraClient_SetAvailableBandwidth,
+MKALL_SET_STRING(MKOrchestraSettings_SetAvailableBandwidth,
                  mkapi_orchestra_client_set_available_bandwidth,
                  mkapi_orchestra_client_t)
 
-MKALL_SET_STRING(MKOrchestraClient_SetDeviceToken,
+MKALL_SET_STRING(MKOrchestraSettings_SetDeviceToken,
                  mkapi_orchestra_client_set_device_token,
                  mkapi_orchestra_client_t)
 
-MKALL_SET_STRING(MKOrchestraClient_SetCABundlePath,
+MKALL_SET_STRING(MKOrchestraSettings_SetCABundlePath,
                  mkapi_orchestra_client_set_ca_bundle_path,
                  mkapi_orchestra_client_t)
 
-MKALL_SET_STRING(MKOrchestraClient_SetGeoIPCountryPath,
+MKALL_SET_STRING(MKOrchestraSettings_SetGeoIPCountryPath,
                  mkapi_orchestra_client_set_geoip_country_path,
                  mkapi_orchestra_client_t)
 
-MKALL_SET_STRING(MKOrchestraClient_SetGeoIPASNPath,
+MKALL_SET_STRING(MKOrchestraSettings_SetGeoIPASNPath,
                  mkapi_orchestra_client_set_geoip_asn_path,
                  mkapi_orchestra_client_t)
 
-MKALL_SET_STRING(MKOrchestraClient_SetLanguage,
+MKALL_SET_STRING(MKOrchestraSettings_SetLanguage,
                  mkapi_orchestra_client_set_language,
                  mkapi_orchestra_client_t)
 
-MKALL_SET_STRING(MKOrchestraClient_SetNetworkType,
+MKALL_SET_STRING(MKOrchestraSettings_SetNetworkType,
                  mkapi_orchestra_client_set_network_type,
                  mkapi_orchestra_client_t)
 
-MKALL_SET_STRING(MKOrchestraClient_SetPlatform,
+MKALL_SET_STRING(MKOrchestraSettings_SetPlatform,
                  mkapi_orchestra_client_set_platform,
                  mkapi_orchestra_client_t)
 
-MKALL_SET_STRING(MKOrchestraClient_SetProbeASN,
+MKALL_SET_STRING(MKOrchestraSettings_SetProbeASN,
                  mkapi_orchestra_client_set_probe_asn,
                  mkapi_orchestra_client_t)
 
-MKALL_SET_STRING(MKOrchestraClient_SetProbeCC,
+MKALL_SET_STRING(MKOrchestraSettings_SetProbeCC,
                  mkapi_orchestra_client_set_probe_cc,
                  mkapi_orchestra_client_t)
 
-MKALL_SET_STRING(MKOrchestraClient_SetProbeFamily,
+MKALL_SET_STRING(MKOrchestraSettings_SetProbeFamily,
                  mkapi_orchestra_client_set_probe_family,
                  mkapi_orchestra_client_t)
 
-MKALL_SET_STRING(MKOrchestraClient_SetProbeTimezone,
+MKALL_SET_STRING(MKOrchestraSettings_SetProbeTimezone,
                  mkapi_orchestra_client_set_probe_timezone,
                  mkapi_orchestra_client_t)
 
-MKALL_SET_STRING(MKOrchestraClient_SetRegistryURL,
+MKALL_SET_STRING(MKOrchestraSettings_SetRegistryURL,
                  mkapi_orchestra_client_set_registry_url,
                  mkapi_orchestra_client_t)
 
-MKALL_SET_STRING(MKOrchestraClient_SetSecretsFile,
+MKALL_SET_STRING(MKOrchestraSettings_SetSecretsFile,
                  mkapi_orchestra_client_set_secrets_file,
                  mkapi_orchestra_client_t)
 
-MKALL_SET_STRING(MKOrchestraClient_SetSoftwareName,
+MKALL_SET_STRING(MKOrchestraSettings_SetSoftwareName,
                  mkapi_orchestra_client_set_software_name,
                  mkapi_orchestra_client_t)
 
-MKALL_SET_STRING(MKOrchestraClient_SetSoftwareVersion,
+MKALL_SET_STRING(MKOrchestraSettings_SetSoftwareVersion,
                  mkapi_orchestra_client_set_software_version,
                  mkapi_orchestra_client_t)
 
-MKALL_SET_STRING(MKOrchestraClient_AddSupportedTest,
+MKALL_SET_STRING(MKOrchestraSettings_AddSupportedTest,
                  mkapi_orchestra_client_add_supported_test,
                  mkapi_orchestra_client_t)
 
-MKALL_SET_LONG(MKOrchestraClient_SetTimeout,
+MKALL_SET_LONG(MKOrchestraSettings_SetTimeout,
                mkapi_orchestra_client_set_timeout,
                mkapi_orchestra_client_t)
 
-MKALL_GET_POINTER(MKOrchestraClient_Sync,
+MKALL_GET_POINTER(MKOrchestraSettings_Sync,
                   mkapi_orchestra_client_sync,
                   mkapi_orchestra_client_t)
 
-MKALL_DELETE(MKOrchestraClient_Delete,
+MKALL_DELETE(MKOrchestraSettings_Delete,
              mkapi_orchestra_client_delete,
              mkapi_orchestra_client_t)

--- a/src/mkall/cpp/version.cpp
+++ b/src/mkall/cpp/version.cpp
@@ -9,6 +9,6 @@
 #include "mkall_util.h"
 
 JNIEXPORT jstring JNICALL
-Java_io_ooni_mk_MKVersion_getVersion(JNIEnv *env, jclass) {
+Java_io_ooni_mk_MKVersion_getVersionMK(JNIEnv *env, jclass) {
   return env->NewStringUTF(MK_VERSION);
 }

--- a/src/mkall/headers/mkall_util.h
+++ b/src/mkall/headers/mkall_util.h
@@ -4,7 +4,9 @@
 #ifndef SRC_MKALL_HEADERS_MKALL_UTIL_H
 #define SRC_MKALL_HEADERS_MKALL_UTIL_H
 
-#include <iostream>
+#include <sstream>
+
+#include <measurement_kit/internal/vendor/mkdata.hpp>
 
 /// MKALL_THROW_RUNTIME_EXCEPTION throws a runtime exception.
 #define MKALL_THROW_RUNTIME_EXCEPTION(text)                    \
@@ -43,31 +45,6 @@
     return cxx_func((cxx_type *)handle) ? JNI_TRUE : JNI_FALSE;        \
   }
 
-/// MKALL_GET_BYTE_ARRAY returns a byte array.
-#define MKALL_GET_BYTE_ARRAY(java_func, cxx_func, cxx_type)               \
-  JNIEXPORT jbyteArray JNICALL                                            \
-      Java_io_ooni_mk_##java_func(JNIEnv *env, jclass, jlong handle) {    \
-    if (handle == 0) {                                                    \
-      MKALL_THROW_EINVAL;                                                 \
-      return nullptr;                                                     \
-    }                                                                     \
-    const uint8_t *base = nullptr;                                        \
-    size_t count = 0;                                                     \
-    /* Implementation note: both in Java and Android jsize is jint */     \
-    cxx_func((cxx_type *)handle, &base, &count);                          \
-    if (base == nullptr || count <= 0 || count > INT_MAX) {               \
-      MKALL_THROW_EINTERNAL;                                              \
-      return nullptr;                                                     \
-    }                                                                     \
-    jbyteArray array = env->NewByteArray((jsize)count);                   \
-    if (array == nullptr) {                                               \
-      /* Exception should already be pending. */                          \
-      return nullptr;                                                     \
-    }                                                                     \
-    env->SetByteArrayRegion(array, 0, (jsize)count, (const jbyte *)base); \
-    return array;                                                         \
-  }
-
 /// MKALL_GET_DOUBLE returns a double value.
 #define MKALL_GET_DOUBLE(java_func, cxx_func, cxx_type)                \
   JNIEXPORT jdouble JNICALL                                            \
@@ -77,6 +54,56 @@
       return 0.0;                                                      \
     }                                                                  \
     return cxx_func((cxx_type *)handle);                               \
+  }
+
+/// MKALL_GET_LOGS returns the logs as a UTF-8 string
+#define MKALL_GET_LOGS(java_func, cxx_func_size, cxx_func_at, cxx_type) \
+  JNIEXPORT jstring JNICALL                                             \
+      Java_io_ooni_mk_##java_func(JNIEnv *env, jclass, jlong handle) {  \
+    if (handle == 0) {                                                  \
+      MKALL_THROW_EINVAL;                                               \
+      return nullptr;                                                   \
+    }                                                                   \
+    std::stringstream ss;                                               \
+    size_t n = cxx_func_size((cxx_type *)handle);                       \
+    for (size_t i = 0; i < n; ++i) {                                    \
+      const char *s = cxx_func_at((cxx_type *)handle, i);               \
+      if (s == nullptr) {                                               \
+        MKALL_THROW_EINVAL;                                             \
+        return nullptr;                                                 \
+      }                                                                 \
+      std::string str = s;                                              \
+      if (!mk::data::contains_valid_utf8(str)) {                        \
+        str = mk::data::base64_encode(std::move(str));                  \
+      }                                                                 \
+      ss << s << std::endl;                                             \
+    }                                                                   \
+    return env->NewStringUTF(ss.str().c_str());                         \
+  }
+
+/// MKALL_GET_LOGS_FROM_BINARY_ARRAY returns the logs as either a
+/// sequence of lines or a single base64 blob, depending on whether
+/// the input binary array is UTF-8 or not.
+#define MKALL_GET_LOGS_FROM_BINARY_ARRAY(java_func, cxx_func, cxx_type) \
+  JNIEXPORT jstring JNICALL                                             \
+      Java_io_ooni_mk_##java_func(JNIEnv *env, jclass, jlong handle) {  \
+    if (handle == 0) {                                                  \
+      MKALL_THROW_EINVAL;                                               \
+      return nullptr;                                                   \
+    }                                                                   \
+    const uint8_t *base = nullptr;                                      \
+    size_t count = 0;                                                   \
+    /* Implementation note: both in Java and Android jsize is jint */   \
+    cxx_func((cxx_type *)handle, &base, &count);                        \
+    if (base == nullptr || count <= 0 || count > INT_MAX) {             \
+      MKALL_THROW_EINTERNAL;                                            \
+      return nullptr;                                                   \
+    }                                                                   \
+    std::string str{(const char *)base, count};                         \
+    if (!mk::data::contains_valid_utf8(str)) {                          \
+      str = mk::data::base64_encode(std::move(str));                    \
+    }                                                                   \
+    return env->NewStringUTF(str.c_str());                              \
   }
 
 /// MKALL_GET_LONG returns a long value.

--- a/src/mkall/headers/mkall_util.h
+++ b/src/mkall/headers/mkall_util.h
@@ -25,10 +25,14 @@
 #define MKALL_THROW_EINTERNAL MKALL_THROW_RUNTIME_EXCEPTION("Internal error")
 
 /// MKALL_CALL calls a void method of a type.
-#define MKALL_CALL(java_func, cxx_func, cxx_type)                   \
-  JNIEXPORT void JNICALL                                            \
-      Java_io_ooni_mk_##java_func(JNIEnv *, jclass, jlong handle) { \
-    cxx_func((cxx_type *)handle);                                   \
+#define MKALL_CALL(java_func, cxx_func, cxx_type)                      \
+  JNIEXPORT void JNICALL                                               \
+      Java_io_ooni_mk_##java_func(JNIEnv *env, jclass, jlong handle) { \
+    if (handle == 0) {                                                 \
+      MKALL_THROW_EINVAL;                                              \
+      return;                                                          \
+    }                                                                  \
+    cxx_func((cxx_type *)handle);                                      \
   }
 
 /// MKALL_DELETE defines a JNI deleter for the specified type.

--- a/src/test/java/io/ooni/mk/MKCollectorResubmitTest.java
+++ b/src/test/java/io/ooni/mk/MKCollectorResubmitTest.java
@@ -1,0 +1,38 @@
+// Part of measurement-kit <https://measurement-kit.github.io/>.
+// Measurement-kit is free software. See AUTHORS and LICENSE for more
+// information on the copying conditions.
+package io.ooni.mk;
+
+import io.ooni.mk.MKCollectorResubmitSettings;
+import io.ooni.mk.MKCollectorResubmitResults;
+
+public class MKCollectorResubmitTest {
+    // This is a compelling argument to always use Kotlin
+    static String origMeasurement = "{\n" +
+            "\"data_format_version\": \"0.2.0\",\n" +
+            "\"input\": \"torproject.org\",\n" +
+            "\"measurement_start_time\": \"2016-06-04 17:53:13\",\n" +
+            "\"probe_asn\": \"AS0\",\n" +
+            "\"probe_cc\": \"ZZ\",\n" +
+            "\"probe_ip\": \"127.0.0.1\",\n" +
+            "\"software_name\": \"measurement_kit\",\n" +
+            "\"software_version\": \"0.2.0-alpha.1\",\n" +
+            "\"test_keys\": {\"failure\": null,\"received\": [],\"sent\": []},\n" +
+            "\"test_name\": \"tcp_connect\",\n" +
+            "\"test_runtime\": 0.253494024276733,\n" +
+            "\"test_start_time\": \"2016-06-04 17:53:13\",\n" +
+            "\"test_version\": \"0.0.1\"\n" +
+        "}\n";
+
+    public static void main(String[] args) {
+        System.loadLibrary("mkall");
+        MKCollectorResubmitSettings settings = new MKCollectorResubmitSettings();
+        settings.setTimeout(14);
+        settings.setCABundlePath("cacert.pem");
+        settings.setSerializedMeasurement(origMeasurement);
+        MKCollectorResubmitResults results = settings.perform();
+        System.out.println("Good         : " + results.isGood());
+        System.out.println("Measurement  : " + results.getUpdatedSerializedMeasurement());
+        System.out.print(results.getLogs());
+    }
+}

--- a/src/test/java/io/ooni/mk/MKGeoIPLookupTest.java
+++ b/src/test/java/io/ooni/mk/MKGeoIPLookupTest.java
@@ -15,13 +15,11 @@ public class MKGeoIPLookupTest {
         settings.setCountryDBPath("country.mmdb");
         settings.setASNDBPath("asn.mmdb");
         MKGeoIPLookupResults results = settings.perform();
-        System.out.println("Good      : " + results.good());
-        System.out.println("Bytes sent: " + results.getBytesSent());
-        System.out.println("Bytes recv: " + results.getBytesRecv());
+        System.out.println("Good      : " + results.isGood());
         System.out.println("Probe IP  : " + results.getProbeIP());
         System.out.println("Probe ASN : " + results.getProbeASN());
         System.out.println("Probe CC  : " + results.getProbeCC());
         System.out.println("Probe Org : " + results.getProbeOrg());
-        System.out.print(new String(results.getLogs()));
+        System.out.print(results.getLogs());
     }
 }

--- a/src/test/java/io/ooni/mk/MKNDTTest.java
+++ b/src/test/java/io/ooni/mk/MKNDTTest.java
@@ -21,10 +21,10 @@ public class MKNDTTest {
             settings += "  }\n";
             settings += "}\n";
         }
-        MKTask task = MKTask.startNettest(settings);
+        MKTask task = MKTask.start(settings);
         while (!task.isDone()) {
-            MKEvent event = task.waitForNextEvent();
-            System.out.println(event.serialize());
+            String event = task.waitForNextEvent();
+            System.out.println(event);
         }
     }
 }

--- a/src/test/java/io/ooni/mk/MKOrchestraTest.java
+++ b/src/test/java/io/ooni/mk/MKOrchestraTest.java
@@ -3,43 +3,43 @@
 // information on the copying conditions.
 package io.ooni.mk;
 
-import io.ooni.mk.MKOrchestraClient;
-import io.ooni.mk.MKOrchestraResult;
+import io.ooni.mk.MKOrchestraSettings;
+import io.ooni.mk.MKOrchestraResults;
 
 public class MKOrchestraTest {
     public static void main(String[] args) {
         System.loadLibrary("mkall");
-        MKOrchestraClient client = new MKOrchestraClient();
-        client.setAvailableBandwidth("10110111");
-        client.setDeviceToken("5f2c761f-2e98-43aa-b9ea-3d34cceaab15");
-        client.setCABundlePath("cacert.pem");
-        client.setGeoIPCountryPath("country.mmdb");
-        client.setGeoIPASNPath("asn.mmdb");
-        client.setLanguage("it_IT");
-        client.setNetworkType("wifi");
-        client.setPlatform("macos");
+        MKOrchestraSettings settings = new MKOrchestraSettings();
+        settings.setAvailableBandwidth("10110111");
+        settings.setDeviceToken("5f2c761f-2e98-43aa-b9ea-3d34cceaab15");
+        settings.setCABundlePath("cacert.pem");
+        settings.setGeoIPCountryPath("country.mmdb");
+        settings.setGeoIPASNPath("asn.mmdb");
+        settings.setLanguage("it_IT");
+        settings.setNetworkType("wifi");
+        settings.setPlatform("macos");
         // Disabled so that the library will need to guess them
-        //client.setProbeASN("AS30722");
-        //client.setProbeCC("IT");
-        client.setProbeFamily("sbs");
-        client.setProbeTimezone("Europe/Rome");
-        client.setRegistryURL("https://registry.proteus.test.ooni.io");
-        client.setSecretsFile(".orchestra.json");
-        client.setSoftwareName("mkall-java");
-        client.setSoftwareVersion("0.1.0");
-        client.addSupportedTest("web_connectivity");
-        client.addSupportedTest("ndt");
-        client.setTimeout(14);
+        //settings.setProbeASN("AS30722");
+        //settings.setProbeCC("IT");
+        settings.setProbeFamily("sbs");
+        settings.setProbeTimezone("Europe/Rome");
+        settings.setRegistryURL("https://registry.proteus.test.ooni.io");
+        settings.setSecretsFile(".orchestra.json");
+        settings.setSoftwareName("mkall-java");
+        settings.setSoftwareVersion("0.1.0");
+        settings.addSupportedTest("web_connectivity");
+        settings.addSupportedTest("ndt");
+        settings.setTimeout(14);
         {
-            MKOrchestraResult result = client.sync();
-            System.out.println("Good      : " + result.good());
-            System.out.print(new String(result.getBinaryLogs()));
+            MKOrchestraResults results = settings.updateOrRegister();
+            System.out.println("Good      : " + results.isGood());
+            System.out.print(results.getLogs());
         }
-        client.setNetworkType("mobile");
+        settings.setNetworkType("mobile");
         {
-            MKOrchestraResult result = client.sync();
-            System.out.println("Good      : " + result.good());
-            System.out.print(new String(result.getBinaryLogs()));
+            MKOrchestraResults results = settings.updateOrRegister();
+            System.out.println("Good      : " + results.isGood());
+            System.out.print(results.getLogs());
         }
     }
 }

--- a/src/test/java/io/ooni/mk/MKVersionTest.java
+++ b/src/test/java/io/ooni/mk/MKVersionTest.java
@@ -8,6 +8,6 @@ import io.ooni.mk.MKVersion;
 public class MKVersionTest {
     public static void main(String[] args) {
         System.loadLibrary("mkall");
-        System.out.println("Version: " + MKVersion.getVersion());
+        System.out.println("Version: " + MKVersion.getVersionMK());
     }
 }

--- a/src/test/java/io/ooni/mk/MKWebConnectivityTest.java
+++ b/src/test/java/io/ooni/mk/MKWebConnectivityTest.java
@@ -26,10 +26,10 @@ public class MKWebConnectivityTest {
             settings += "  }\n";
             settings += "}\n";
         }
-        MKTask task = MKTask.startNettest(settings);
+        MKTask task = MKTask.start(settings);
         while (!task.isDone()) {
-            MKEvent event = task.waitForNextEvent();
-            System.out.println(event.serialize());
+            String event = task.waitForNextEvent();
+            System.out.println(event);
         }
     }
 }


### PR DESCRIPTION
1. hide MKEvent since we can just move around strings

2. use more Java friendly method names, e.g. `isGood` rather than `good`, since that is more common in Java

3. use more consistent naming, for which we have in input settings and in output results in all cases; this is exactly what I already did for mkall-ios

4. start adding Javadoc documentation

5. update JNI code and tests

6. add support for resubmitting a report